### PR TITLE
Fix new editor empty (#955)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "uri", "0.10.0.1"
 # Use Puma as the app server
 gem "haml"
 gem "jsbundling-rails"
-gem "kredis", "~> 1.1"
+gem "kredis", "~> 1.3"
 gem "propshaft"
 gem "puma", "~> 6.0"
 gem "sassc"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -336,7 +336,7 @@ GEM
     http-cookie (1.0.4)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
-    i18n (1.13.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     i18n-js (4.0.0.alpha2)
       glob
@@ -366,9 +366,9 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
-    kredis (1.1.0)
+    kredis (1.3.0.1)
       activesupport (>= 6.0.0)
-      redis (~> 4.2)
+      redis (>= 4.2, < 6)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -721,7 +721,7 @@ DEPENDENCIES
   jwe
   jwt
   kaminari (~> 1.2)
-  kredis (~> 1.1)
+  kredis (~> 1.3)
   listen (>= 3.0.5, < 3.2)
   mini_magick (~> 4.8)
   mustache

--- a/app/javascript/src/pages/conversations/newEditor.tsx
+++ b/app/javascript/src/pages/conversations/newEditor.tsx
@@ -342,6 +342,7 @@ export default class ChatEditor extends Component<
   };
 
   isDocEmpty = (docJSON) => {
+    if (!docJSON) return true;
     const { content } = docJSON;
 
     if (!content || content.length === 0) {

--- a/app/services/message_apis/csat/api.rb
+++ b/app/services/message_apis/csat/api.rb
@@ -102,7 +102,7 @@ module MessageApis::Csat
     def send_survey(subject)
       data = MessageApis::Csat::Presenter.csat_buttons
 
-      author = subject.app.agents.first
+      author = subject.app.agents.bots.first
 
       controls = {
         app_package: "Csat",


### PR DESCRIPTION
* Bump kredis from 1.1.0 to 1.3.0.1

Bumps [kredis](https://github.com/rails/kredis) from 1.1.0 to 1.3.0.1.
- [Release notes](https://github.com/rails/kredis/releases)
- [Commits](https://github.com/rails/kredis/compare/v1.1.0...v1.3.0.1)

---
updated-dependencies:
- dependency-name: kredis dependency-type: direct:production ...



* fix editor isEmpty on new conversation

---------